### PR TITLE
Fix: 添加空值检查以防止访问 undefined 的 value 属性

### DIFF
--- a/app.ts
+++ b/app.ts
@@ -137,7 +137,12 @@ rl.on('line', async (input) => {
             if(isInteger(args[1])) {
                 play_nfa = parseInt(args[1], 10);
                 let results = await taiyi.api.evalNfaActionWithStringArgsAsync(play_nfa, "short", "[]");
-                console.log(`你好，${ANSI.YEL}${results.eval_result[0].value.v}${ANSI.NOR}（#${play_nfa}）。`);
+                console.log(`你好，${ANSI.YEL}${
+                  results.eval_result && 
+                  results.eval_result[0] && 
+                  results.eval_result[0].value ? 
+                  results.eval_result[0].value.v : '未知'
+                }${ANSI.NOR}（#${play_nfa}）。`);
                 console.log(`注意，你的元神现在在一个物品里面，不要做出太出格的事情。\n`);
                 rl.prompt();
             }


### PR DESCRIPTION
## 修复 TypeError: Cannot read properties of undefined (reading 'value')

### 问题描述
在运行 `yarn start` 命令时，当 `results.eval_result[0]` 为 undefined 或没有 value 属性时，
会抛出 TypeError 错误。

### 解决方案
添加了空值检查，确保在访问 `results.eval_result[0].value.v` 之前验证所有对象和属性是否存在。
如果不存在，则显示"未知"作为默认值。

### 测试
已在本地测试，确认修复后不再出现该错误。